### PR TITLE
debugger: set appropriate secure flag on cookie

### DIFF
--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -450,6 +450,7 @@ class DebuggedApplication:
                 f"{int(time.time())}|{hash_pin(pin)}",
                 httponly=True,
                 samesite="None",
+                secure=request.is_secure,
             )
         elif bad_cookie:
             rv.delete_cookie(self.pin_cookie_name)


### PR DESCRIPTION
When using the debugger on an https site, Chrome was refusing to use the cookie.

Related to https://github.com/pallets/werkzeug/issues/1912 but for https/secure now.

- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
