### PR TITLE
add MarkupSafe dependency to docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,9 @@ Python 3.7 and newer.
 Dependencies
 ------------
 
-Werkzeug does not have any direct dependencies.
+Werkzeug depends on `MarkupSafe`_
+
+.. _MarkupSafe: https://pypi.org/project/MarkupSafe/
 
 
 Optional dependencies


### PR DESCRIPTION
Since https://github.com/pallets/werkzeug/pull/2448, there has been a dependency on MarkupSafe, so updating the docs that still said no direct dependencies